### PR TITLE
Small fix of gb3s1518.bwfon font

### DIFF
--- a/src/jpcsp/HLE/kernel/types/SceFontInfoBW.java
+++ b/src/jpcsp/HLE/kernel/types/SceFontInfoBW.java
@@ -89,7 +89,6 @@ public class SceFontInfoBW extends SceFontInfo {
 
     	charInfo.bitmapWidth = charBitmapWidth;
     	charInfo.bitmapHeight = charBitmapHeight + 1;
-    	charInfo.bitmapTop = charBitmapWidth;
     	charInfo.sfp26Width = charBitmapWidth << 6;
     	charInfo.sfp26Height = (charBitmapHeight + 1) << 6;
     	charInfo.sfp26Ascender = charBitmapHeight << 6;


### PR DESCRIPTION
Tested with Comic party chinese patch

Before
![1](https://cloud.githubusercontent.com/assets/2177532/10226360/8237c056-6899-11e5-8b0b-83851ed9173e.jpg)

After
![2](https://cloud.githubusercontent.com/assets/2177532/10226363/861da096-6899-11e5-83cd-2d9073fbcc00.jpg)
