### PR TITLE
Fix scePowerSetClockFrequency timing

### DIFF
--- a/src/jpcsp/HLE/modules/scePower.java
+++ b/src/jpcsp/HLE/modules/scePower.java
@@ -517,38 +517,59 @@ public class scePower extends HLEModule {
         return (float) pllClock;
     }
 
-    @HLELogging(level="info")
     @HLEFunction(nid = 0x737486F2, version = 150)
     public int scePowerSetClockFrequency(int pllClock, int cpuClock, int busClock) {
-        this.pllClock = pllClock;
+        if (cpuClock == 0 || cpuClock > 333) {
+        	log.warn(String.format("scePowerSetClockFrequency invalid frequency pllClock %d cpuClock %d busClock %d",pllClock,cpuClock,busClock));
+        	return SceKernelErrors.ERROR_INVALID_VALUE;
+        }
+
+        log.info(String.format("scePowerSetClockFrequency pllClock %d cpuClock %d busClock %d",pllClock,cpuClock,busClock));
         this.cpuClock = cpuClock;
         this.busClock = busClock;
+        if (this.pllClock != pllClock) {
+        	this.pllClock = pllClock;
 
-        Modules.ThreadManForUserModule.hleKernelDelayThread(150000, false);
+        	Modules.ThreadManForUserModule.hleKernelDelayThread(150000, false);
+        }
         return 0;
     }
 
-    @HLELogging(level="info")
     @HLEFunction(nid = 0xEBD177D6, version = 150)
     public int scePower_EBD177D6(int pllClock, int cpuClock, int busClock) {
         // Identical to scePowerSetClockFrequency.
-        this.pllClock = pllClock;
+        if (cpuClock == 0 || cpuClock > 333) {
+        	log.warn(String.format("scePower_EBD177D6 invalid frequency pllClock %d cpuClock %d busClock %d",pllClock,cpuClock,busClock));
+        	return SceKernelErrors.ERROR_INVALID_VALUE;
+        }
+
+        log.info(String.format("scePower_EBD177D6 pllClock %d cpuClock %d busClock %d",pllClock,cpuClock,busClock));
         this.cpuClock = cpuClock;
         this.busClock = busClock;
+        if (this.pllClock != pllClock) {
+        	this.pllClock = pllClock;
 
-        Modules.ThreadManForUserModule.hleKernelDelayThread(150000, false);
+        	Modules.ThreadManForUserModule.hleKernelDelayThread(150000, false);
+        }
         return 0;
     }
 
-    @HLELogging(level="info")
     @HLEFunction(nid = 0x469989AD, version = 630)
     public int scePower_469989AD(int pllClock, int cpuClock, int busClock) {
         // Identical to scePowerSetClockFrequency.
-        this.pllClock = pllClock;
+        if (cpuClock == 0 || cpuClock > 333) {
+        	log.warn(String.format("scePower_469989AD invalid frequency pllClock %d cpuClock %d busClock %d",pllClock,cpuClock,busClock));
+        	return SceKernelErrors.ERROR_INVALID_VALUE;
+        }
+
+        log.info(String.format("scePower_469989AD pllClock %d cpuClock %d busClock %d",pllClock,cpuClock,busClock));
         this.cpuClock = cpuClock;
         this.busClock = busClock;
+        if (this.pllClock != pllClock) {
+        	this.pllClock = pllClock;
 
-        Modules.ThreadManForUserModule.hleKernelDelayThread(150000, false);
+        	Modules.ThreadManForUserModule.hleKernelDelayThread(150000, false);
+        }
         return 0;
     }
 


### PR DESCRIPTION
and add check frequency

F1 2009 keep calling scePowerSetClockFrequency so that the game is slow
 I find out by JPCSPTrace log that same ClockFrequency do not delay

{the syscall parameters have
 to be logged before and after the syscall (i.e. twice)}

scePower_EBD177D6 0xEBD177D6 3 !ddd
 Patching syscall from 0x80F0804 to 0x9FFFF10

04:26:16.778 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
 04:26:16.778 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
 04:26:16.788 user_main - sceKernelCreateThread 0x09FFF4F0('FileLoadThread_0x08c1f140'), 0x88B5858, 19, 0x800, 0x0, 0x0 = 0xCA9F57
 04:26:16.808 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
 04:26:16.809 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
 04:26:16.842 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
 04:26:16.842 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
 04:26:16.908 user_main - scePower_EBD177D6 222, 222, 111 = 0x0
 04:26:16.909 user_main - scePower_EBD177D6 222, 222, 111 = 0x0

jpcsp modify log: https://gist.github.com/sum2012/bd7eb503c560b44d731bf7638cecdc15