### PR TITLE
Update LogSettings.xml

### DIFF
--- a/LogSettings.xml
+++ b/LogSettings.xml
@@ -32,6 +32,7 @@
   <appender name="TxtAppender" class="org.apache.log4j.FileAppender">
     <param name="File" value="log.txt" />
     <param name="Append" value="false" />
+    <param name="Encoding" value="UTF-8" />
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern" value="%d{HH:mm:ss} %5p %8c - %t - %m%n" />
     </layout>


### PR DESCRIPTION
As mentioned in the commit message, adding this line allows any generated logs to properly display messages shown in an East Asian language. It can also help the log that gets saved to a text file display complex characters that are used in certain languages. While the emulator is running, the logger uses proper encoding to display all the characters. When the log gets saved to a text file, no encoding is used which means certain characters get replaced by question marks.

Game Title Example (Logger):
```TITLE = 遊☆戯☆王 アーク・ファイブ タッグフォース スペシャル```
Game Title Example (Log.txt):
```TITLE = ????? ???????? ??????? ?????```

sceUtility Example (Logger):
```
INFO hle.sceUtility - user_main - sceUtilityMsgDialogInitStart 0x08D5C760-0x08D5CA24: result 0x00000000
mode PSP_UTILITY_MSGDIALOG_MODE_TEXT
errorValue 0x00000000
message '本タイトルはオートセーブ機能に対応しています。
オートセーブ中には"メモリースティック"アクセス
ランプが点滅しますので、その間は記録メディアを
抜いたり、本体の電源を切ったりしないでください。'
options 0x000000A1
buttonPressed 0x00000000'
enterButtonString ''
backButtonString ''
```
sceUtility Example (Log.txt):
```
INFO hle.sceUtility - user_main - sceUtilityMsgDialogInitStart 0x08D5C760-0x08D5CA24: result 0x00000000
mode PSP_UTILITY_MSGDIALOG_MODE_TEXT
errorValue 0x00000000
message '???????????????????????
?????????"?????????"????
???????????????????????
????????????????????????'
options 0x000000A1
buttonPressed 0x00000000'
enterButtonString ''
backButtonString ''
```