### PR TITLE
Update Gradle build support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ group 'com.jpcsp'
 version '0.7'
 
 buildscript {
-    ext.launch4j_version = '1.6.2'
+    ext.launch4j_version = '2.4.4'
 
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
@@ -82,7 +82,7 @@ jar {
 }
 
 launch4j {
-    opt = "-Xmx768m"
+    jvmOptions = ['-Xmx768m']
     print "version: $version"
     outfile = "../../build/libs/jpcsp-${project.version}.exe"
     icon = "../../resources/jpcsp/icon.ico"


### PR DESCRIPTION
Update Gradle newer launch4j version  for fix 

```
* What went wrong:
A problem occurred evaluating root project 'jpcsp'.
> Lorg/gradle/listener/ActionBroadcast;
```
```
launch4j.opt property is deprecated. Use launch4j.jvmOptions instead.

```
Also change opt to jvmOptions = [' '] because opt is deprecated now