### PR TITLE
Revert SWR MIPS improvement

### DIFF
--- a/src/jpcsp/Allegrex/Instructions.java
+++ b/src/jpcsp/Allegrex/Instructions.java
@@ -4516,6 +4516,8 @@ public void interpret(Processor processor, int insn) {
 }
 @Override
 public void compile(ICompilerContext context, int insn) {
+	context.compileRTRSIMM("doSWR", true);
+	/* need fix below
 	if (!context.isRtRegister0()) {
 		MethodVisitor mv = context.getMethodVisitor();
 		int simm16 = context.getImm16(true);
@@ -4543,6 +4545,7 @@ public void compile(ICompilerContext context, int insn) {
 		mv.visitInsn(Opcodes.IOR);
 		context.memWrite32(context.getRsRegisterIndex(), simm16, true);
 	}
+	*/
 }
 @Override
 public String disasm(int address, int insn) {


### PR DESCRIPTION
This revert part of https://github.com/jpcsp/jpcsp/commit/7136396995479b2c37761291e945f3f18c7a258a

Fix  loading problem of Downstream Panic! - ULUS10322

modify log: https://drive.google.com/file/d/1HIPCYTz725A1cx1Ty4hy93OPq0QfpnGi/view?usp=sharing

It is still better fix rather revert.