### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,49 +23,49 @@ jobs:
       - name: Build with Ant
         run: ant -f build-auto.xml dist
         
-      - name: Move builds to apporiate artifact folders
+      - name: Move builds to appropriate artifact folders
         run: |
-          # Remove all unnecessary build folders since we will only release builds with archived with 7zip
+          # Remove all unnecessary build folders since we will only release builds archived with 7-Zip
           cd dist
           rm -R -- */
           cd ..
-          # Make directories for artifact releases and move all of builds to their respective folders
-          mkdir -p dist/{buildWin32/x86,buildWin32/amd64,buildLinux/x86,buildLinux/amd64,buildMacOS}
+          # Make directories for artifact releases and move each build to their respective folders
+          mkdir -p dist/{buildWindows/x86,buildWindows/amd64,buildLinux/x86,buildLinux/amd64,buildmacOS}
           mv dist/*linux-amd64* dist/buildLinux/amd64/
           mv dist/*linux-x86* dist/buildLinux/x86/
-          mv dist/*windows-x86* dist/buildWin32/x86/
-          mv dist/*windows-amd64* dist/buildWin32/amd64/
-          mv dist/*macosx* dist/buildMacOS/
+          mv dist/*windows-x86* dist/buildWindows/x86/
+          mv dist/*windows-amd64* dist/buildWindows/amd64/
+          mv dist/*macosx* dist/buildmacOS/
      
-      - name: Publishing Win32 x86 build
+      - name: Publishing Windows 32-bit build
         uses: actions/upload-artifact@v2
         with:
-          name: Win32 x86 build
-          path: dist/buildWin32/x86
+          name: Windows 32-bit build
+          path: dist/buildWindows/x86
 
-      - name: Publishing Win32 amd64 build
+      - name: Publishing Windows 64-bit build
         uses: actions/upload-artifact@v2
         with:
-          name: Win32 amd64 build
-          path: dist/buildWin32/amd64
+          name: Windows 64-bit build
+          path: dist/buildWindows/amd64
       
-      - name: Publishing Linux x86 build
+      - name: Publishing Linux 32-bit build
         uses: actions/upload-artifact@v2
         with:
-          name: Linux x86 build
+          name: Linux 32-bit build
           path: dist/buildLinux/x86
 
-      - name: Publishing Linux amd64 build
+      - name: Publishing Linux 64-bit build
         uses: actions/upload-artifact@v2
         with:
-          name: Linux amd64 build
+          name: Linux 64-bit build
           path: dist/buildLinux/amd64
 
-      - name: Publishing MacOS build
+      - name: Publishing macOS build
         uses: actions/upload-artifact@v2
         with:
-          name: Mac OS build
-          path: dist/buildMacOS
+          name: macOS build
+          path: dist/buildmacOS
           
       - name: Release tagged builds
         uses: softprops/action-gh-release@v1
@@ -75,6 +75,6 @@ jobs:
           files: |
             dist/buildLinux/x86/*.7z
             dist/buildLinux/amd64/*.7z
-            dist/buildMacOS/*.7z
-            dist/buildWin32/x86/*.7z
-            dist/buildWin32/amd64/*.7z
+            dist/buildmacOS/*.7z
+            dist/buildWindows/x86/*.7z
+            dist/buildWindows/amd64/*.7z


### PR DESCRIPTION
Fix typos and rename builds to reflect current OS naming standards (e.g. Win32 -> Windows, Mac OS -> macOS)

@FollowerOfBigboss Is there a way to have the artifacts not create a zip file on top of the 7-Zip file for each build?