### PR TITLE
Add patch file for Saints Row: Undercover (Prototype)

### DIFF
--- a/patches/ULUS12345-6E197A8FB304B3DB.properties
+++ b/patches/ULUS12345-6E197A8FB304B3DB.properties
@@ -1,0 +1,4 @@
+# Saints Row: Undercover (Prototype)
+# UMD_DATA.BIN contains "ULUS-12345|6E197A8FB304B3DB|0001|G             |"
+memory64MB=true
+maxTextureSize=1024


### PR DESCRIPTION
Saints Row: Undercover (Prototype) requires 64 MB of RAM in order to run on the emulator.