### PR TITLE
Update Windows 32-bit & 64-bit batch file

### DIFF
--- a/start-windows-amd64.bat
+++ b/start-windows-amd64.bat
@@ -28,7 +28,7 @@ if not exist "%JAVA_CMD%" goto JAVAMISSING
 
 :RUN
 echo Running Jpcsp 64bit...
-"%JAVA_CMD%" -Xmx2048m -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-amd64;lib/jinput-2.0.9-natives-all -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows.jar" jpcsp.MainGUI %*
+"%JAVA_CMD%" -Xmx2048m -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-amd64;lib/jinput-2.0.9-natives-all -Dorg.lwjgl.system.allocator=system -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-glfw.jar;lib/lwjgl-3.2.3/lwjgl-glfw-natives-windows.jar" jpcsp.MainGUI %*
 if ERRORLEVEL 1 goto PAUSE
 goto END
 

--- a/start-windows-x86.bat
+++ b/start-windows-x86.bat
@@ -35,7 +35,7 @@ ver | findstr "5\.1\." > nul
 if %ERRORLEVEL% EQU 0 set MAX_MEM_SIZE=768m
 
 echo Running Jpcsp 32bit...
-"%JAVA_CMD%" -Xmx%MAX_MEM_SIZE% -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-x86;lib/jinput-2.0.9-natives-all -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows-x86.jar" jpcsp.MainGUI %*
+"%JAVA_CMD%" -Xmx%MAX_MEM_SIZE% -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-x86;lib/jinput-2.0.9-natives-all -Dorg.lwjgl.system.allocator=system -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-glfw.jar;lib/lwjgl-3.2.3/lwjgl-glfw-natives-windows-x86.jar" jpcsp.MainGUI %*
 if ERRORLEVEL 1 goto PAUSE
 goto END
 


### PR DESCRIPTION
For Java 11 and above, the classpath of all glfw files need to be added or else the emulator doesn't work.