### PR TITLE
let fuse commands through in HLE SAVEDATA

### DIFF
--- a/src/jpcsp/crypto/SAVEDATA.java
+++ b/src/jpcsp/crypto/SAVEDATA.java
@@ -151,11 +151,6 @@ public class SAVEDATA {
         // Set the the data size to size.
     	writeUnaligned32(buf, 16, size);
 
-        // Ignore PSP_KIRK_CMD_ENCRYPT_FUSE and PSP_KIRK_CMD_DECRYPT_FUSE. 
-        if (kirk_code == KIRK.PSP_KIRK_CMD_ENCRYPT_FUSE || kirk_code == KIRK.PSP_KIRK_CMD_DECRYPT_FUSE) {
-            return; 
-        }
-
         ByteBuffer bBuf = ByteBuffer.wrap(buf).order(ByteOrder.LITTLE_ENDIAN);
         kirk.hleUtilsBufferCopyWithRange(bBuf, size, bBuf, size + 20, kirk_code);
     }


### PR DESCRIPTION
Placeholder kirk code KIRK.PSP_KIRK_CMD_ENCRYPT_FUSE and KIRK.PSP_KIRK_CMD_DECRYPT_FUSE were implemented for LLE, let it through

Noticed that it didn't fire CMD5 while working on a homebrew using HLE sceChnnlsv, which in turn re-uses SAVEDATA. Expected cmd5 to fire in trace but it didn't

This patch was done to help verify https://github.com/bucanero/apollo-psp/pull/23

This would also allow saves made in HLE sceUtility to load with firmware utility.prx in games that checks for SceUtilitySavedataParam.bind, such as Gran Turismo