### PR TITLE
Improve start-windows-x86 batch script

### DIFF
--- a/start-windows-x86.bat
+++ b/start-windows-x86.bat
@@ -1,5 +1,5 @@
 @echo off
-rem change to the directory where the script itself; this is required when running as an adminstrator
+rem change to the directory where the script itself; this is required when running as an administrator
 cd /d "%~dp0"
 
 rem check if java is installed
@@ -16,7 +16,7 @@ ver | findstr "5\.1\." 2> nul
 if %errorlevel% equ 0 ( set MAX_MEM_SIZE=768m ) else ( set MAX_MEM_SIZE=1024m )
 
 java -version
-echo Java Executable Path: %JAVA_CMD%
+echo JAVA_HOME Path: %JAVA_HOME%
 
 echo Running JPCSP 32-bit...
 %JAVA_CMD%^

--- a/start-windows-x86.bat
+++ b/start-windows-x86.bat
@@ -1,51 +1,37 @@
 @echo off
-rem CD to the path of the command line, this is required when running as an administrator
-cd /D "%~dp0"
+rem change to the directory where the script itself; this is required when running as an adminstrator
+cd /d "%~dp0"
 
-set PATH=%PATH%;lib\;lib\windows-x86\
-
-if NOT EXIST "%SystemRoot%\SysWOW64" goto JAVA32
-set key=HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\JavaSoft\Java Runtime Environment
-goto JAVA
-
-:JAVA32
-set key=HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\Java Runtime Environment
-
-:JAVA
-set JAVA_CMD=%ProgramFiles%\Java\jre7\bin\java.exe
-if not exist "%JAVA_CMD%" set JAVA_CMD=java.exe
-
-rem Checking if the "reg" command is available
-reg /? >NUL 2>NUL
-if ERRORLEVEL 1 goto RUN
-
-set JAVA_VERSION=
-set JAVA_HOME=
-for /f "tokens=3* skip=2" %%a in ('reg query "%key%" /v CurrentVersion') do set JAVA_VERSION=%%a
-for /f "tokens=2* skip=2" %%a in ('reg query "%key%\%JAVA_VERSION%" /v JavaHome') do set JAVA_HOME=%%b
-
-set JAVA_CMD=%JAVA_HOME%\bin\java.exe
-if not exist "%JAVA_CMD%" goto JAVAMISSING
+rem check if java is installed
+java -help 2> nul
+if %errorlevel% equ 0 (
+    rem check the path of java executable if exist and configured
+    set JAVA_CMD="%JAVA_HOME%\bin\java.exe"
+    if exist %JAVA_CMD% ( goto RUN ) else ( goto JAVA_MISSING )
+) else ( goto JAVA_MISSING )
 
 :RUN
-
 rem Use -Xmx768m for Windows XP, -Xmx1024m for all other Windows versions
-set MAX_MEM_SIZE=1024m
-ver | findstr "5\.1\." > nul
-if %ERRORLEVEL% EQU 0 set MAX_MEM_SIZE=768m
+ver | findstr "5\.1\." 2> nul
+if %errorlevel% equ 0 ( set MAX_MEM_SIZE=768m ) else ( set MAX_MEM_SIZE=1024m )
 
-echo Running Jpcsp 32bit...
-"%JAVA_CMD%" -Xmx%MAX_MEM_SIZE% -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-x86;lib/jinput-2.0.9-natives-all -Dorg.lwjgl.system.allocator=system -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-glfw.jar;lib/lwjgl-3.2.3/lwjgl-glfw-natives-windows-x86.jar" jpcsp.MainGUI %*
-if ERRORLEVEL 1 goto PAUSE
-goto END
+java -version
+echo Java Executable Path: %JAVA_CMD%
 
-:JAVAMISSING
-echo The required version of Java has not been installed or isn't recognized.
-echo Go to
-echo     http://www.oracle.com/technetwork/java/javase/downloads/index.html
-echo to install the "Windows x86" Java JRE.
+echo Running JPCSP 32-bit...
+%JAVA_CMD%^
+    -Xmx%MAX_MEM_SIZE% -Xss2m -XX:ReservedCodeCacheSize=64m^
+    -Djava.library.path=lib/windows-x86;lib/jinput-2.0.9-natives-all^
+    -Djinput.useDefaultPlugin=false^
+    -Dorg.lwjgl.system.allocator=system^
+    -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-glfw.jar;lib/lwjgl-3.2.3/lwjgl-glfw-natives-windows-x86.jar"^
+    jpcsp.MainGUI %*
+exit
 
-:PAUSE
+:JAVA_MISSING
+echo The required version of Java Runtime Environment(JRE) has not been installed or isn't recognized.
+echo Go to https://adoptium.net/temurin/releases/ to install the 32bit(x86) JRE.
+echo NOTE:
+echo   If you already installed the JRE then you need to set up the JAVA_HOME variable
+echo   and add to the PATH with \bin like this: %%JAVA_HOME%%\bin
 pause
-
-:END


### PR DESCRIPTION
Hi, I just wanna to propose my improvements to the `start-windows-x86` batch script

- simplify java detection
- more verbose like printing the JDK and JRE version and the value of JAVA_HOME variable
- update java binaries source link