### PR TITLE
fix Netbeans 20 build lzma error

### DIFF
--- a/lib/nblibraries.properties
+++ b/lib/nblibraries.properties
@@ -43,3 +43,5 @@ libs.junit_4.classpath=\
 	${base}/junit-4.13.2.jar
 libs.hamcrest.classpath=\
 	${base}/hamcrest-2.2.jar
+libs.xz-1.9.classpath=\
+        ${base}/xz-1.9.jar

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -45,7 +45,8 @@ javac.classpath=\
     ${libs.junit_4.classpath}:\
     ${libs.hamcrest.classpath}:\
     ${libs.BouncyCastle-1.6.9.classpath}:\
-    ${libs.jide-oss-3.7.12.classpath}
+    ${libs.jide-oss-3.7.12.classpath}:\
+    ${libs.xz-1.9.classpath}
 
 javac.processorpath=\
     ${javac.classpath}


### PR DESCRIPTION
fix for `error package org.tukaani.xz does not exist` when building jpcsp using Netbeans 20