### PR TITLE
Improve 32-bit & 64-bit start windows script

### DIFF
--- a/start-windows-amd64.bat
+++ b/start-windows-amd64.bat
@@ -14,7 +14,7 @@ set JAVA_CMD="%JAVA_HOME%\bin\java.exe"
 if not exist %JAVA_CMD% ( goto JAVA_MISSING )
 
 rem check java if can run 64-bit application
-java -d64 -version > nul 2>&1
+java -version 2>&1 | findstr /i "64-Bit" > nul
 if not %errorlevel% equ 0 ( goto JAVA_ARCH )
 
 java -version

--- a/start-windows-amd64.bat
+++ b/start-windows-amd64.bat
@@ -1,52 +1,51 @@
 @echo off
-rem CD to the path of the command line, this is required when running as an administrator
-cd /D "%~dp0"
+rem change to the directory where the script itself; this is required when running as an administrator
+cd /d "%~dp0"
 
-set PATH=%PATH%;lib\;lib\windows-amd64\
+rem check if 64-bit OS
+if not exist "%SYSTEMROOT%\SysWOW64" ( goto OS_ARCH )
 
-if NOT EXIST "%SystemRoot%\SysWOW64" goto JAVA32
+rem check if java is installed
+java -help 2> nul
+if not %errorlevel% equ 0 ( goto JAVA_MISSING )
 
-if "%ProgramFiles%" == "%ProgramFiles(x86)%" goto JAVA32SHELL
+rem check the path of java executable if exist and configured
+set JAVA_CMD="%JAVA_HOME%\bin\java.exe"
+if not exist %JAVA_CMD% ( goto JAVA_MISSING )
 
-set JAVA_CMD=java.exe
-where /q java.exe
-if ERRORLEVEL 0 goto RUN
+rem check java if can run 64-bit application
+java -d64 -version > nul 2>&1
+if not %errorlevel% equ 0 ( goto JAVA_ARCH )
 
-rem Checking if the "reg" command is available
-reg /? >NUL 2>NUL
-if ERRORLEVEL 1 goto RUN
+java -version
+echo JAVA_HOME Path: %JAVA_HOME%
 
-set key=HKEY_LOCAL_MACHINE\SOFTWARE\JavaSoft\Java Runtime Environment
-set JAVA_VERSION=
-set JAVA_HOME=
-for /f "tokens=3* skip=2" %%a in ('reg query "%key%" /v CurrentVersion') do set JAVA_VERSION=%%a
-for /f "tokens=2* skip=2" %%a in ('reg query "%key%\%JAVA_VERSION%" /v JavaHome') do set JAVA_HOME=%%b
-
-set JAVA_CMD=%JAVA_HOME%\bin\java.exe
-if not exist "%JAVA_CMD%" set JAVA_CMD=%ProgramFiles(x86)%\Java\jre7\bin\java.exe
-if not exist "%JAVA_CMD%" goto JAVAMISSING
-
-:RUN
-echo Running Jpcsp 64bit...
-"%JAVA_CMD%" -Xmx2048m -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-amd64;lib/jinput-2.0.9-natives-all -Dorg.lwjgl.system.allocator=system -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-glfw.jar;lib/lwjgl-3.2.3/lwjgl-glfw-natives-windows.jar" jpcsp.MainGUI %*
-if ERRORLEVEL 1 goto PAUSE
+echo Running JPCSP 64-bit...
+%JAVA_CMD%^
+    -Xmx2048m -Xss2m -XX:ReservedCodeCacheSize=64m^
+    -Djava.library.path=lib/windows-amd64;lib/jinput-2.0.9-natives-all^
+    -Djinput.useDefaultPlugin=false^
+    -Dorg.lwjgl.system.allocator=system^
+    -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows.jar;lib/lwjgl-3.2.3/lwjgl-glfw.jar;lib/lwjgl-3.2.3/lwjgl-glfw-natives-windows.jar"^
+    jpcsp.MainGUI %*
 goto END
 
-:JAVA32
-echo Unable to run a 64bit build on a 32bit platform. Install a 64bit version of Windows first.
-goto PAUSE
+:OS_ARCH
+echo Unable to run a 64-bit JPCSP on a 32-bit system. Install a 64-bit version of Windows first
+echo or download the 32-bit JPCSP from https://jpcsp.org/index?p=downloads.
+goto END
 
-:JAVA32SHELL
-echo Unable to properly run a 64bit application from a 32bit context on a 64bit platform.
-goto PAUSE
+:JAVA_ARCH
+echo Unable to properly run a 64-bit JPCSP from 32-bit JRE on a 64-bit system.
+goto END
 
-:JAVAMISSING
-echo The required version of Java has not been installed.
-echo Go to
-echo     http://www.oracle.com/technetwork/java/javase/downloads/index.html
-echo to install the "Windows x64" Java JRE.
-
-:PAUSE
-pause
+:JAVA_MISSING
+echo The required version of Java Runtime Environment(JRE) has not been installed or isn't recognized.
+echo Go to https://adoptium.net/temurin/releases/ to install the 64-bit(x64) JRE.
+echo NOTE:
+echo   If you already installed the JRE then you need to set up the JAVA_HOME variable
+echo   and add to the PATH with \bin like this: %%JAVA_HOME%%\bin
+goto END
 
 :END
+pause

--- a/start-windows-x86.bat
+++ b/start-windows-x86.bat
@@ -4,13 +4,12 @@ cd /d "%~dp0"
 
 rem check if java is installed
 java -help 2> nul
-if %errorlevel% equ 0 (
-    rem check the path of java executable if exist and configured
-    set JAVA_CMD="%JAVA_HOME%\bin\java.exe"
-    if exist %JAVA_CMD% ( goto RUN ) else ( goto JAVA_MISSING )
-) else ( goto JAVA_MISSING )
+if not %errorlevel% equ 0 ( goto JAVA_MISSING )
 
-:RUN
+rem check the path of java executable if exist and configured
+set JAVA_CMD="%JAVA_HOME%\bin\java.exe"
+if not %errorlevel% equ 0 ( goto JAVA_MISSING )
+
 rem Use -Xmx768m for Windows XP, -Xmx1024m for all other Windows versions
 ver | findstr "5\.1\." 2> nul
 if %errorlevel% equ 0 ( set MAX_MEM_SIZE=768m ) else ( set MAX_MEM_SIZE=1024m )
@@ -26,12 +25,21 @@ echo Running JPCSP 32-bit...
     -Dorg.lwjgl.system.allocator=system^
     -classpath "bin/jpcsp.jar;lib/lwjgl-3.2.3/lwjgl.jar;lib/lwjgl-3.2.3/lwjgl-openal.jar;lib/lwjgl-3.2.3/lwjgl-opengl.jar;lib/lwjgl-3.2.3/lwjgl-jawt.jar;lib/lwjgl-3.2.3/lwjgl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-openal-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-opengl-natives-windows-x86.jar;lib/lwjgl-3.2.3/lwjgl-glfw.jar;lib/lwjgl-3.2.3/lwjgl-glfw-natives-windows-x86.jar"^
     jpcsp.MainGUI %*
-exit
+    if not %errorlevel% equ 0 ( goto JAVA_ARCH )
+goto END
 
 :JAVA_MISSING
 echo The required version of Java Runtime Environment(JRE) has not been installed or isn't recognized.
-echo Go to https://adoptium.net/temurin/releases/ to install the 32bit(x86) JRE.
+echo Go to https://adoptium.net/temurin/releases/ to install the 32-bit(x86) JRE.
 echo NOTE:
 echo   If you already installed the JRE then you need to set up the JAVA_HOME variable
 echo   and add to the PATH with \bin like this: %%JAVA_HOME%%\bin
+goto END
+
+:JAVA_ARCH
+echo Unable to properly run a 32-bit JPCSP from a 64-bit JRE on a 64-bit system 
+echo because the 32-bit application needs a build from 32-bit libraries.
+goto END
+
+:END
 pause


### PR DESCRIPTION
- concise error information
- just check for errors only to improve code readability
- simplify java detection in 64-bit script same as 32-bit script