### PR TITLE
fix NetBeans 20 UnsatisfiedLinkError

### DIFF
--- a/nbproject/configs/Run__Windows-amd64_.properties
+++ b/nbproject/configs/Run__Windows-amd64_.properties
@@ -1,2 +1,2 @@
 $label=Run (Windows-amd64)
-run.jvmargs=-ea -Xmx1024m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-amd64
+run.jvmargs=-ea -Xmx1024m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-amd64;lib/jinput-2.0.9-natives-all

--- a/nbproject/configs/Run__Windows-x86_.properties
+++ b/nbproject/configs/Run__Windows-x86_.properties
@@ -1,2 +1,2 @@
 $label=Run (Windows-x86)
-run.jvmargs=-Xmx1024m -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-x86
+run.jvmargs=-Xmx1024m -Xss2m -XX:ReservedCodeCacheSize=64m -Djava.library.path=lib/windows-x86;lib/jinput-2.0.9-natives-all


### PR DESCRIPTION
fix for `java.lang.UnsatisfiedLinkError: no jinput-dx8_64` and `java.lang.UnsatisfiedLinkError: no jinput-raw_64`errors on both windows' run properties of netbeans 20