### PR TITLE
Improve About dialog window

### DIFF
--- a/src/jpcsp/MainGUI.java
+++ b/src/jpcsp/MainGUI.java
@@ -1834,7 +1834,7 @@ private void AboutActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:e
             .append("<hr/>")
             .append("<h2>Jpcsp Present Team</h2>")
             .append("<h3><font color='gray'>" + MetaInformation.TEAM + "</font></h3>")
-            .append("<h2>Jpcsp Past Members and Contributors</h2>")
+            .append("<h2>Past Members and Contributors</h2>")
             .append("<h3><font color='gray'>" + MetaInformation.PAST_TEAM + "</font></h3>")
             .append("</center></body></html>");
         JEditorPane msg = new JEditorPane();

--- a/src/jpcsp/MainGUI.java
+++ b/src/jpcsp/MainGUI.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.RandomAccessFile;
 import java.net.InetAddress;
+import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.security.Security;
@@ -48,6 +49,7 @@ import java.util.*;
 import java.util.List;
 
 import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
 
 import jpcsp.Allegrex.compiler.Profiler;
 import jpcsp.Allegrex.compiler.RuntimeContext;
@@ -1847,7 +1849,19 @@ private void AboutActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:e
                 .append(MetaInformation.TEAM)
                 .append("</font>")
                 .append("</html>");
-        JOptionPane.showMessageDialog(this, message.toString(), MetaInformation.FULL_NAME, JOptionPane.INFORMATION_MESSAGE);
+        JEditorPane msg = new JEditorPane();
+        msg.addHyperlinkListener(link -> { // make all hyperlinks clickable
+            if (link.getEventType().equals(HyperlinkEvent.EventType.ACTIVATED)) {
+                try { Desktop.getDesktop().browse(link.getURL().toURI()); }
+                catch (URISyntaxException | IOException ex) { ex.printStackTrace(); }
+            }
+        });
+        msg.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, Boolean.TRUE); // use default look and feel
+        msg.setContentType("text/html");
+        msg.setEditable(false);
+        msg.setOpaque(false);
+        msg.setText(message.toString());
+        JOptionPane.showMessageDialog(this, msg, MetaInformation.FULL_NAME, JOptionPane.INFORMATION_MESSAGE);
 }//GEN-LAST:event_AboutActionPerformed
 
 private void ConfigMenuActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_ConfigMenuActionPerformed

--- a/src/jpcsp/MainGUI.java
+++ b/src/jpcsp/MainGUI.java
@@ -1824,31 +1824,19 @@ private void EnterImageViewerActionPerformed(java.awt.event.ActionEvent evt) {//
 private void AboutActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_AboutActionPerformed
         StringBuilder message = new StringBuilder();
         message
-                .append("<html>")
-                .append("<h2>")
-                .append(MetaInformation.FULL_NAME)
-                .append("</h2>")
-                .append("<hr/>")
-                .append("Official site      : <a href='")
-                .append(MetaInformation.OFFICIAL_SITE)
-                .append("'>")
-                .append(MetaInformation.OFFICIAL_SITE)
-                .append("</a><br/>")
-                .append("Official forum     : <a href='")
-                .append(MetaInformation.OFFICIAL_FORUM)
-                .append("'>")
-                .append(MetaInformation.OFFICIAL_FORUM)
-                .append("</a><br/>")
-                .append("Official repository: <a href='")
-                .append(MetaInformation.OFFICIAL_REPOSITORY)
-                .append("'>")
-                .append(MetaInformation.OFFICIAL_REPOSITORY)
-                .append("</a><br/>")
-                .append("<hr/>")
-                .append("<i>Team:</i> <font color='gray'>")
-                .append(MetaInformation.TEAM)
-                .append("</font>")
-                .append("</html>");
+            .append("<html><body><center>")
+            .append("<h1>" + MetaInformation.FULL_NAME + "</h1>")
+            .append("<hr/>")
+            .append("<h2>Official Links</h2>")
+            .append("<p><b>Website:</b> <a href='" + MetaInformation.OFFICIAL_SITE + "'>" + MetaInformation.OFFICIAL_SITE + "</a></p>")
+            .append("<p><b>Forum:</b> <a href='" + MetaInformation.OFFICIAL_FORUM + "'>" + MetaInformation.OFFICIAL_FORUM + "</a></p>")
+            .append("<p><b>Source repository:</b> <a href='" + MetaInformation.OFFICIAL_REPOSITORY + "'>" + MetaInformation.OFFICIAL_REPOSITORY + "</a></p>")
+            .append("<hr/>")
+            .append("<h2>Jpcsp Present Team</h2>")
+            .append("<h3><font color='gray'>" + MetaInformation.TEAM + "</font></h3>")
+            .append("<h2>Jpcsp Past Members and Contributors</h2>")
+            .append("<h3><font color='gray'>" + MetaInformation.PAST_TEAM + "</font></h3>")
+            .append("</center></body></html>");
         JEditorPane msg = new JEditorPane();
         msg.addHyperlinkListener(link -> { // make all hyperlinks clickable
             if (link.getEventType().equals(HyperlinkEvent.EventType.ACTIVATED)) {
@@ -1861,7 +1849,7 @@ private void AboutActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:e
         msg.setEditable(false);
         msg.setOpaque(false);
         msg.setText(message.toString());
-        JOptionPane.showMessageDialog(this, msg, MetaInformation.FULL_NAME, JOptionPane.INFORMATION_MESSAGE);
+        JOptionPane.showMessageDialog(this, msg, "About", JOptionPane.PLAIN_MESSAGE);
 }//GEN-LAST:event_AboutActionPerformed
 
 private void ConfigMenuActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_ConfigMenuActionPerformed

--- a/src/jpcsp/util/MetaInformation.java
+++ b/src/jpcsp/util/MetaInformation.java
@@ -24,10 +24,10 @@ public class MetaInformation {
     public static String NAME = "Jpcsp";
     public static String VERSION = "v0.7";
     public static String FULL_NAME = NAME + " " + VERSION;
-    public static String OFFICIAL_SITE = "http://jpcsp.org/";
-    public static String OFFICIAL_FORUM = "http://www.emunewz.net/forum/forumdisplay.php?fid=51";
+    public static String OFFICIAL_SITE = "https://jpcsp.org/";
+    public static String OFFICIAL_FORUM = "https://www.emunewz.net/forum/forumdisplay.php?fid=51";
     public static String OFFICIAL_REPOSITORY = "https://github.com/jpcsp/jpcsp";
-    public static String TEAM = "JPCSP Team: gid15, Hykem, Orphis, shadow.<br/>" +
+    public static String TEAM = "JPCSP Team: gid15, Hykem, Orphis, shadow and nickblame.<br/>" +
             "Past members and contributors: hlide, mad, dreampeppers99, wrayal,<br/> fiveofhearts, Nutzje, aisesal, shashClp, spip2, mozvip, gigaherz, <br/>Drakon, raziel1000, theball, J_BYYX, i30817, tempura.san.";
 
     private MetaInformation() {

--- a/src/jpcsp/util/MetaInformation.java
+++ b/src/jpcsp/util/MetaInformation.java
@@ -28,7 +28,7 @@ public class MetaInformation {
     public static String OFFICIAL_FORUM = "https://www.emunewz.net/forum/forumdisplay.php?fid=51";
     public static String OFFICIAL_REPOSITORY = "https://github.com/jpcsp/jpcsp";
     public static String TEAM = "gid15 <br/>";
-    public static String PAST_TEAM = "Hykem, Orphis, shadow, hlide, mad, dreampeppers99, wrayal, <br/>" +
+    public static String PAST_TEAM = "Hykem, Orphis, shadow, nickblame, hlide, mad, dreampeppers99, wrayal, <br/>" +
         "fiveofhearts, Nutzje, aisesal, shashClp, spip2, mozvip, gigaherz, <br/>" +
         "Drakon, raziel1000, theball, J_BYYX, i30817, tempura.san";
 

--- a/src/jpcsp/util/MetaInformation.java
+++ b/src/jpcsp/util/MetaInformation.java
@@ -24,11 +24,13 @@ public class MetaInformation {
     public static String NAME = "Jpcsp";
     public static String VERSION = "v0.7";
     public static String FULL_NAME = NAME + " " + VERSION;
-    public static String OFFICIAL_SITE = "https://jpcsp.org/";
+    public static String OFFICIAL_SITE = "https://jpcsp.org";
     public static String OFFICIAL_FORUM = "https://www.emunewz.net/forum/forumdisplay.php?fid=51";
     public static String OFFICIAL_REPOSITORY = "https://github.com/jpcsp/jpcsp";
-    public static String TEAM = "JPCSP Team: gid15, Hykem, Orphis, shadow and nickblame.<br/>" +
-            "Past members and contributors: hlide, mad, dreampeppers99, wrayal,<br/> fiveofhearts, Nutzje, aisesal, shashClp, spip2, mozvip, gigaherz, <br/>Drakon, raziel1000, theball, J_BYYX, i30817, tempura.san.";
+    public static String TEAM = "gid15 <br/>";
+    public static String PAST_TEAM = "Hykem, Orphis, shadow, hlide, mad, dreampeppers99, wrayal, <br/>" +
+        "fiveofhearts, Nutzje, aisesal, shashClp, spip2, mozvip, gigaherz, <br/>" +
+        "Drakon, raziel1000, theball, J_BYYX, i30817, tempura.san";
 
     private MetaInformation() {
         try {


### PR DESCRIPTION
I want to propose this improvements of `About` dialog in Jpcsp and let me know if there's more, thanks!

<img src="https://github.com/jpcsp/jpcsp/assets/71203851/cf1e2c1d-4556-47ca-a553-32184e81a986" width="300px">

improvements:
- clickable hyperlinks
- bigger text and add emphasize in hierarchy of the text using heading tag
- set title of the dialog according to the button
- update team members based on the README and Jpcsp website

additional request in this PR:
- add nickblame as a part of the Jpcsp